### PR TITLE
Properly log proxied remote ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2019-10-15
+
+* Added
+  * Properly log proxied remote IPs
+
 ## 2019-04-17
 
 * Added

--- a/rootfs/etc/apache2/apache2.conf
+++ b/rootfs/etc/apache2/apache2.conf
@@ -17,9 +17,9 @@ AccessFileName ${APACHE_ACCESS_FILE_NAME}
 ErrorLog ${APACHE_ERROR_LOG}
 LogLevel ${APACHE_LOG_LEVEL}
 
-LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" \"%{X-Request-ID}i\"" requestid
-LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" \"%{X-Request-ID}i\"" requestid
+LogFormat "%a %l %u %t \"%r\" %>s %O" common
 
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf

--- a/rootfs/etc/apache2/conf-enabled/remoteip.conf
+++ b/rootfs/etc/apache2/conf-enabled/remoteip.conf
@@ -1,0 +1,1 @@
+RemoteIPHeader X-Forwarded-For


### PR DESCRIPTION
This change is required to get the right IP propagated into the logs if ownCloud is running behind a reverse proxy. This fixes https://github.com/owncloud-docker/base/issues/99 for images based on owncloud/php:latest.