### PR TITLE
fix: setup php module smbclient during container build

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \
+  echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
+  phpenmod smbclient && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \
+  echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
+  phpenmod smbclient && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \
+  echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
+  phpenmod smbclient && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \

--- a/latest/overlay/etc/entrypoint.d/98-php.sh
+++ b/latest/overlay/etc/entrypoint.d/98-php.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-phpenmod smbclient
-
-true

--- a/latest/overlay/etc/php/7.4/mods-available/smbclient.ini
+++ b/latest/overlay/etc/php/7.4/mods-available/smbclient.ini
@@ -1,1 +1,0 @@
-extension=smbclient.so

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \
+  echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
+  phpenmod smbclient && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \
+  echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
+  phpenmod smbclient && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \
+  echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
+  phpenmod smbclient && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \

--- a/v20.04/overlay/etc/entrypoint.d/98-php.sh
+++ b/v20.04/overlay/etc/entrypoint.d/98-php.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-phpenmod smbclient
-
-true

--- a/v20.04/overlay/etc/php/7.4/mods-available/smbclient.ini
+++ b/v20.04/overlay/etc/php/7.4/mods-available/smbclient.ini
@@ -1,1 +1,0 @@
-extension=smbclient.so


### PR DESCRIPTION
As https://github.com/owncloud-docker/php/pull/27  breaks the ability to run the container in environments using unprivileged arbitrary UID's we need to enable the extension during container build.