### PR TITLE
fix: add .cache dir with proper permissions 

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \
-  chown -R www-data:www-data /var/www/html /var/log/apache2 /var/run/apache2 && \
+  mkdir -p /var/www/.cache && \
+  chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   apt-get purge -y php-dev libsmbclient-dev && \

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \
-  chown -R www-data:www-data /var/www/html /var/log/apache2 /var/run/apache2 && \
+  mkdir -p /var/www/.cache && \
+  chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   apt-get purge -y php-dev libsmbclient-dev && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \
-  chown -R www-data:www-data /var/www/html /var/log/apache2 /var/run/apache2 && \
+  mkdir -p /var/www/.cache && \
+  chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   apt-get purge -y php-dev libsmbclient-dev && \

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \
-  chown -R www-data:www-data /var/www/html /var/log/apache2 /var/run/apache2 && \
+  mkdir -p /var/www/.cache && \
+  chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   apt-get purge -y php-dev libsmbclient-dev && \

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \
-  chown -R www-data:www-data /var/www/html /var/log/apache2 /var/run/apache2 && \
+  mkdir -p /var/www/.cache && \
+  chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   apt-get purge -y php-dev libsmbclient-dev && \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /etc/apache2/envvars /etc/apache2/conf-* /etc/apache2/sites-* /var/log/apache2/* && \
   a2enmod rewrite headers env dir mime expires remoteip && \
   mkdir -p /var/www/html && \
-  chown -R www-data:www-data /var/www/html /var/log/apache2 /var/run/apache2 && \
+  mkdir -p /var/www/.cache && \
+  chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   apt-get purge -y php-dev libsmbclient-dev && \


### PR DESCRIPTION
Supersedes: https://github.com/owncloud-docker/php/pull/83/files

Required by the cronjob for WND process queue, e.g. `occ wnd:process-queue host.docker.internal smbshare`. It calls smbclient under the hood, which in this case wants to create a file `/var/www/.cache/samba/gencache.tdb`. For security reasons, `www-data` has no permissions to create new directories in `/var/www`.