### PR TITLE
chore: remove further unnecessary packages

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -34,9 +34,6 @@ RUN apt-get update -y && \
     php-dev libsmbclient-dev \
     php-gmp \
     smbclient \
-    patch \
-    mysql-client \
-    postgresql-client \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -34,9 +34,6 @@ RUN apt-get update -y && \
     php-dev libsmbclient-dev \
     php-gmp \
     smbclient \
-    patch \
-    mysql-client \
-    postgresql-client \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -34,9 +34,6 @@ RUN apt-get update -y && \
     php-dev libsmbclient-dev \
     php-gmp \
     smbclient \
-    patch \
-    mysql-client \
-    postgresql-client \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -34,9 +34,6 @@ RUN apt-get update -y && \
     php-dev libsmbclient-dev \
     php-gmp \
     smbclient \
-    patch \
-    mysql-client \
-    postgresql-client \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -34,9 +34,6 @@ RUN apt-get update -y && \
     php-dev libsmbclient-dev \
     php-gmp \
     smbclient \
-    patch \
-    mysql-client \
-    postgresql-client \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -34,9 +34,6 @@ RUN apt-get update -y && \
     php-dev libsmbclient-dev \
     php-gmp \
     smbclient \
-    patch \
-    mysql-client \
-    postgresql-client \
     sqlite && \
   apt-get clean && \
   pecl install smbclient-stable && \


### PR DESCRIPTION
Only the `php-*` packages for mariadb/postgres should be required.