### PR TITLE
ci: disable arm32 container builds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -10,7 +10,6 @@ def main(ctx):
 
     arches = [
         "amd64",
-        "arm32v7",
         "arm64v8",
     ]
 


### PR DESCRIPTION
Disable arm32 due to the discontinued upstream Docker-in-Docker container.
Ref: https://github.com/owncloud/enterprise/issues/5536