### PR TITLE
Added imagick 7 for heic support

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -45,13 +45,12 @@ RUN apt-get update -y && \
   mkdir -p /var/www/.cache && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
-  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  curl -sSL https://dist.1-2.dev/imei.sh | bash && \
-  pecl channel-update pecl.php.net && echo | pecl install imagick && \
-  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils && \
-  apt-get purge -y php-dev libsmbclient-dev php-pear make && \
+  curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  echo | pecl install imagick && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
-  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* && \
+  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean
 
 ADD overlay /

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -23,7 +23,6 @@ RUN apt-get update -y && \
     php-pgsql \
     php-curl \
     php-intl \
-    php-imagick \
     php-zip \
     php-xml \
     php-mbstring \
@@ -47,8 +46,12 @@ RUN apt-get update -y && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  curl -sSL https://dist.1-2.dev/imei.sh | bash && \
+  pecl channel-update pecl.php.net && echo | pecl install imagick && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils && \
   apt-get purge -y php-dev libsmbclient-dev php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
+  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* && \
   apt-get clean
 
 ADD overlay /

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -23,7 +23,6 @@ RUN apt-get update -y && \
     php-pgsql \
     php-curl \
     php-intl \
-    php-imagick \
     php-zip \
     php-xml \
     php-mbstring \
@@ -46,9 +45,12 @@ RUN apt-get update -y && \
   mkdir -p /var/www/.cache && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
-  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  apt-get purge -y php-dev libsmbclient-dev php-pear make && \
+  curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  echo | pecl install imagick && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
+  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean
 
 ADD overlay /

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -45,13 +45,12 @@ RUN apt-get update -y && \
   mkdir -p /var/www/.cache && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
-  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  curl -sSL https://dist.1-2.dev/imei.sh | bash && \
-  pecl channel-update pecl.php.net && echo | pecl install imagick && \
-  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils && \
-  apt-get purge -y php-dev libsmbclient-dev php-pear make && \
+  curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  echo | pecl install imagick && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
-  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* && \
+  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean
 
 ADD overlay /

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -23,7 +23,6 @@ RUN apt-get update -y && \
     php-pgsql \
     php-curl \
     php-intl \
-    php-imagick \
     php-zip \
     php-xml \
     php-mbstring \
@@ -47,8 +46,12 @@ RUN apt-get update -y && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  curl -sSL https://dist.1-2.dev/imei.sh | bash && \
+  pecl channel-update pecl.php.net && echo | pecl install imagick && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils && \
   apt-get purge -y php-dev libsmbclient-dev php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
+  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* && \
   apt-get clean
 
 ADD overlay /

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -23,7 +23,6 @@ RUN apt-get update -y && \
     php-pgsql \
     php-curl \
     php-intl \
-    php-imagick \
     php-zip \
     php-xml \
     php-mbstring \
@@ -46,9 +45,12 @@ RUN apt-get update -y && \
   mkdir -p /var/www/.cache && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
-  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  apt-get purge -y php-dev libsmbclient-dev php-pear make && \
+  curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  echo | pecl install imagick && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
+  rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean
 
 ADD overlay /


### PR DESCRIPTION
Fixes: https://github.com/owncloud-docker/php/issues/46
Obsoletes: https://github.com/owncloud-docker/server/pull/407

As recommended in our documentation, we build via imei.sh -- this installs an additional toolchain as defined in
https://github.com/SoftCreatR/imei/blob/main/imei.sh#L494

Imei.sh lacks a cleanup step, I've added that to our Dockerfiles to keep the image size down.
The sizes are:

`docker images | grep local-`
```
local-owncloud-php                      heic-purge-all    a111a8abadc2   10 seconds ago      460MB
local-owncloud-php                      before-heic       c536a14fdf3a   2 hours ago         442MB
```