### PR TITLE
fix https://github.com/owncloud/core/issues/40929

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2023-08-18
+
+* Added
+  * ImageMagic-7 via imei.sh for heic support
+
 ## 2020-05-25
 
 * Added

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | env BUILD_CFLAGS="-O2 -mtune=generic" BUILD_CXXFLAGS="-O2 -mtune=generic" bash && \
   echo | pecl install imagick && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | env BUILD_CFLAGS="-O2 -mtune=generic" BUILD_CXXFLAGS="-O2 -mtune=generic" bash && \
   echo | pecl install imagick && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | env BUILD_CFLAGS="-O2 -mtune=generic" BUILD_CXXFLAGS="-O2 -mtune=generic" bash && \
   echo | pecl install imagick && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
   chown -R www-data:www-data /var/www/html /var/www/.cache /var/log/apache2 /var/run/apache2 && \
   chsh -s /bin/bash www-data && \
   curl -sSfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-  curl -sSfL https://dist.1-2.dev/imei.sh | bash && \
+  curl -sSfL https://dist.1-2.dev/imei.sh | env BUILD_CFLAGS="-O2 -mtune=generic" BUILD_CXXFLAGS="-O2 -mtune=generic" bash && \
   echo | pecl install imagick && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \


### PR DESCRIPTION
Default BUILDFLAGS of the imei.sh scripts include "-O3 -march=native" which makes us compatible with different CPUs.
That is definitly the wrong choice for docker based use! Followup in -> https://github.com/SoftCreatR/imei/issues/83

Fixes: https://github.com/owncloud/core/issues/40929
Fixes: https://github.com/owncloud/core/issues/40933