### PR TITLE
fix: assert that ghostscript and librsvg are in the image

### DIFF
--- a/v20.04/Dockerfile.multiarch
+++ b/v20.04/Dockerfile.multiarch
@@ -58,7 +58,8 @@ RUN apt-get update -y && \
   echo | pecl install imagick && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \
-  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ ghostscript gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
+  apt-get install --no-install-recommends -y librsvg2-common ghostscript && \
   apt-get update && apt-get -y --purge autoremove && \
   rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean

--- a/v20.04/Dockerfile.multiarch
+++ b/v20.04/Dockerfile.multiarch
@@ -42,7 +42,9 @@ RUN apt-get update -y && \
     libde265-0 \
     libx265-179 \
     exiftool \
-    sqlite3 && \
+    sqlite3 \
+    librsvg2-common \
+    ghostscript && \
   pecl channel-update pecl.php.net && \
   pecl install smbclient-stable && \
   echo 'extension=smbclient.so' > /etc/php/7.4/mods-available/smbclient.ini && \
@@ -59,7 +61,6 @@ RUN apt-get update -y && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \
   apt-get purge -y '*-dev' git cmake automake libtool yasm g++ gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
-  apt-get install --no-install-recommends -y librsvg2-common ghostscript && \
   apt-get update && apt-get -y --purge autoremove && \
   rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean


### PR DESCRIPTION
Ghostscript was explicitly removed during build env cleanup. librsvg was a candidate for autoremove.

Fixes: https://github.com/owncloud/core/issues/41185
Fixes: https://github.com/owncloud/core/issues/41208

This increases the image size by 75 MB (now 1.07 GB). 


Note: SVG and PDF preview remain disabled per default. You still need to add
 - `OC\Preview\PDF`
 - `OC\Preview\SVG`

to the environment variable OWNCLOUD_ENABLED_PREVIEW_PROVIDERS for this.