### PR TITLE
fix: must keep shared-mime-info for librsvg

### DIFF
--- a/v20.04/Dockerfile.multiarch
+++ b/v20.04/Dockerfile.multiarch
@@ -60,7 +60,7 @@ RUN apt-get update -y && \
   echo | pecl install imagick && \
   echo 'extension=imagick.so' > /etc/php/7.4/mods-available/imagick.ini && \
   phpenmod imagick && \
-  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ gsfonts ffmpeg less pkg-config shared-mime-info xz-utils php-pear make && \
+  apt-get purge -y '*-dev' git cmake automake libtool yasm g++ gsfonts ffmpeg less pkg-config xz-utils php-pear make && \
   apt-get update && apt-get -y --purge autoremove && \
   rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean


### PR DESCRIPTION
Having all installs before the purge has the disadvantage, that we cannot assert presence of any particular package without checking all dependencies.

librsvg is a soft dependency of imagemagic only, but has a hard dependency on shared-mime-info.
If we delete the latter, this auto-removes librsvg and leaves us with reduced functionalty of imagemagic.