### PR TITLE
chore: switch to Freexian PHP 7.4 on Ubuntu 20.04

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -170,6 +170,7 @@ def prepublish(config):
                     "from_secret": "internal_password",
                 },
                 "tags": config["internal"],
+                "build_args_from_env": ["DEB_MIRROR_URL", "DEB_MIRROR_LOGIN", "DEB_MIRROR_PWD"],
                 "dockerfile": "%s/Dockerfile.multiarch" % (config["version"]["path"]),
                 "repo": "registry.drone.owncloud.com/owncloud/%s" % config["repo"],
                 "registry": "registry.drone.owncloud.com",
@@ -178,6 +179,15 @@ def prepublish(config):
             },
             "environment": {
                 "BUILDKIT_NO_CLIENT_TOKEN": True,
+                "DEB_MIRROR_URL": {
+                    "from_secret": "DEB_MIRROR_URL",
+                },
+                "DEB_MIRROR_LOGIN": {
+                    "from_secret": "DEB_MIRROR_LOGIN",
+                },
+                "DEB_MIRROR_PWD": {
+                    "from_secret": "DEB_MIRROR_PWD",
+                },
             },
         },
     ]
@@ -254,10 +264,22 @@ def publish(config):
                     "linux/arm64",
                 ],
                 "tags": config["version"]["tags"],
+                "build_args_from_env": ["DEB_MIRROR_URL", "DEB_MIRROR_LOGIN", "DEB_MIRROR_PWD"],
                 "dockerfile": "%s/Dockerfile.multiarch" % (config["version"]["path"]),
                 "repo": "owncloud/%s" % config["repo"],
                 "context": config["version"]["path"],
                 "pull_image": False,
+            },
+            "environment": {
+                "DEB_MIRROR_URL": {
+                    "from_secret": "DEB_MIRROR_URL",
+                },
+                "DEB_MIRROR_LOGIN": {
+                    "from_secret": "DEB_MIRROR_LOGIN",
+                },
+                "DEB_MIRROR_PWD": {
+                    "from_secret": "DEB_MIRROR_PWD",
+                },
             },
             "when": {
                 "ref": [

--- a/v20.04/Dockerfile.multiarch
+++ b/v20.04/Dockerfile.multiarch
@@ -7,10 +7,23 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/php" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/php"
 
+ARG DEB_MIRROR_URL
+ARG DEB_MIRROR_LOGIN
+ARG DEB_MIRROR_PWD
+
 EXPOSE 8080
 
 ENTRYPOINT ["/usr/bin/entrypoint"]
 CMD ["/usr/bin/server"]
+
+# Get the key that the Freexian deb mirror uses for signing
+RUN wget http://php.freexian.com/public/archive-key.gpg -O /etc/apt/trusted.gpg.d/freexian-archive-php.gpg
+# Get the authentication details for the deb mirror that has been set up to serve the Freexian PHP packages
+RUN echo "machine $DEB_MIRROR_URL login $DEB_MIRROR_LOGIN password $DEB_MIRROR_PWD" > /etc/apt/auth.conf.d/freexian.conf
+
+RUN apt-get update -y && \
+  apt-get install -y software-properties-common language-pack-en-base && \
+  apt-add-repository "https://$DEB_MIRROR_URL/php.freexian.com/ bookworm main"
 
 RUN apt-get update -y && \
   apt-get install --no-install-recommends -y \
@@ -64,6 +77,9 @@ RUN apt-get update -y && \
   apt-get update && apt-get -y --purge autoremove && \
   rm -rf /var/lib/apt/lists/* /usr/local/share/doc/* /usr/local/include/* /tmp/* && \
   apt-get clean
+
+# delete the file that has the authentication for the Freexian deb package server, so that it can't end up in the built docker image
+RUN rm -f /etc/apt/auth.conf.d/freexian.conf
 
 ADD overlay /
 WORKDIR /var/www/html


### PR DESCRIPTION
This seems to work, keeping Ubuntu 20.04 as the base.
IMO, we may as well do this now, then try to get things working for Ubuntu 22.04 in PR #185 