### PR TITLE
fix: delegate lint-pr-title to reusable ubuntu workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -9,8 +9,5 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: owncloud-docker/ubuntu/.github/workflows/lint-pr-title.yml@master
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces the inline copy of `amannn/action-semantic-pull-request` with a call to the reusable `lint-pr-title.yml` workflow in `owncloud-docker/ubuntu`
- Keeps lint behaviour identical; centralises the action pin in one place

## Why

All owncloud-docker repos should delegate to the shared reusable workflow rather than maintain their own inline copies, so upgrades to the action only need to happen in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)