### PR TITLE
feat: add PHP version smoke test to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     uses: owncloud-docker/ubuntu/.github/workflows/lint-editorconfig.yml@master
 
   build:
+    name: build (${{ matrix.version.value }})
     needs: lint
     uses: owncloud-docker/ubuntu/.github/workflows/docker-build.yml@master
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,11 @@ jobs:
     uses: owncloud-docker/ubuntu/.github/workflows/docker-build.yml@master
     with:
       docker-repo-name: owncloud/${{ github.event.repository.name }}
-      docker-tag: ${{ matrix.version }}
-      docker-context: v${{ matrix.version }}
-      docker-file: v${{ matrix.version }}/Dockerfile.multiarch
+      docker-tag: ${{ matrix.version.value }}
+      docker-context: v${{ matrix.version.value }}
+      docker-file: v${{ matrix.version.value }}/Dockerfile.multiarch
       docker-hub-username: ${{ vars.DOCKERHUB_USERNAME }}
+      smoke-test-cmd: ${{ matrix.version.smoke-test-cmd }}
       push: ${{ github.ref == 'refs/heads/master' }}
     secrets:
       docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -30,7 +31,11 @@ jobs:
 
     strategy:
       matrix:
-        version: ["22.04", "24.04"]
+        version:
+          - value: "22.04"
+            smoke-test-cmd: "php --version | grep -qF 'PHP 7.4'"
+          - value: "24.04"
+            smoke-test-cmd: "php --version | grep -qF 'PHP 8.3'"
 
   update-docker-hub-description:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 mirror-auth
 mirror-url
+
+docs/superpowers/


### PR DESCRIPTION
## Summary

- Restructures `matrix.version` from a flat string array to an object array, mirroring the pattern used in `owncloud-docker/ubuntu`
- Adds per-version `smoke-test-cmd`: verifies `PHP 7.4` for `22.04` and `PHP 8.3` for `24.04`
- Passes `smoke-test-cmd` to the reusable `docker-build.yml` workflow, which runs it as a one-shot `docker run --rm` check after the image is built

## Test Plan

- [ ] CI builds both matrix versions and runs the smoke test step
- [ ] `php --version | grep -qF 'PHP 7.4'` passes for the `22.04` image
- [ ] `php --version | grep -qF 'PHP 8.3'` passes for the `24.04` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)