### PR TITLE
chore: update dependabot to weekly Sunday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: github-actions
+    directory: "/"
     schedule:
-      interval: "weekly"
-
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This PR adds/updates the Dependabot configuration for this repository.

Dependabot is configured to run weekly (Sunday at 22:00 UTC) with a limit of 5 open pull requests per ecosystem. Minor and patch updates are grouped into a single PR per ecosystem to reduce the number of concurrent update PRs, lowering maintainer overhead and CI load. Major version updates remain as individual PRs so they receive deliberate review.
