### PR TITLE
feat: add smbclient to the image

### DIFF
--- a/v24.04/Dockerfile.multiarch
+++ b/v24.04/Dockerfile.multiarch
@@ -33,6 +33,7 @@ RUN apt-get update -y && \
   php8.3-gmp \
   php8.3-imagick \
   php8.3-smbclient \
+  smbclient \
   # libldap-common is required to install /etc/ldap/ldap.conf which is a must have to allow proper ldap operations
   libldap-common \
   libimage-exiftool-perl \


### PR DESCRIPTION
This PR adds `smbclient` (the CLI tool) to the image.

This image is used in `base` which then is used in `server`.
In server, we need smbclient because it is necessary to be able to test if you can get a connection to the smb host. This is a part of the prerequisites/troubleshooting smb issues in the documentation. With a plain install, this is easy to post add, but with docker only (oc11), it must be in the image.

@DeepDiver1975 