### PR TITLE
feat: add php-memcached extension to all images

### DIFF
--- a/v22.04/Dockerfile.multiarch
+++ b/v22.04/Dockerfile.multiarch
@@ -40,6 +40,7 @@ RUN apt-get update -y && \
   php7.4-ldap \
   php7.4-apcu php7.4-apcu-bc \
   php7.4-redis \
+  php7.4-memcached \
   php7.4-gmp \
   php7.4-imagick \
   php7.4-smbclient \

--- a/v24.04/Dockerfile.multiarch
+++ b/v24.04/Dockerfile.multiarch
@@ -30,6 +30,7 @@ RUN apt-get update -y && \
   php8.3-ldap \
   php8.3-apcu \
   php8.3-redis \
+  php8.3-memcached \
   php8.3-gmp \
   php8.3-imagick \
   php8.3-smbclient \


### PR DESCRIPTION
## Context

The `owncloud/base` image exposes `OWNCLOUD_MEMCACHED_*` env vars that configure `\OC\Memcache\Memcached`, but none of the php images shipped a memcached PHP extension — only `apcu` and `redis`. That made the memcached caching backend **dead config** at runtime across all versions.

## Change

Add the memcached extension next to the existing `redis` line in each image:

| Image | Added |
|---|---|
| v22.04 | `php7.4-memcached` |
| v24.04 | `php8.3-memcached` |

## Companion PR

This unblocks owncloud-docker/base#481, which restores the `OWNCLOUD_MEMCACHED_*` env-var surface in v24.04. That PR should land after this one ships and the base image's php digest is bumped.

## Verification

After build/publish:
```
docker run --rm owncloud/php:24.04 php -m | grep -i memcached
docker run --rm owncloud/php:22.04 php -m | grep -i memcached
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)